### PR TITLE
Avoid `Path::with_extension` because it can replace extension

### DIFF
--- a/repak_cli/src/main.rs
+++ b/repak_cli/src/main.rs
@@ -290,10 +290,14 @@ fn unpack(aes_key: Option<aes::Aes256>, action: ActionUnpack) -> Result<(), repa
 }
 
 fn pack(args: ActionPack) -> Result<(), repak::Error> {
-    let output = args
-        .output
-        .map(PathBuf::from)
-        .unwrap_or_else(|| Path::new(&args.input).with_extension("pak"));
+    let output = args.output.map(PathBuf::from).unwrap_or_else(|| {
+        let mut output = PathBuf::new();
+        output.push(&args.input);
+        // NOTE: don't use `with_extension` here because it will replace e.g. the `.1` in
+        // `test_v1.1`.
+        output.push(".pak");
+        output
+    });
 
     fn collect_files(paths: &mut Vec<PathBuf>, dir: &Path) -> io::Result<()> {
         for entry in fs::read_dir(dir)? {


### PR DESCRIPTION
Don't use `Path::with_extension` for making pak output path because it will replace e.g. the `.1` in the input folder name `test_v1.1`.