### PR TITLE
api fixes

### DIFF
--- a/repak/src/pak.rs
+++ b/repak/src/pak.rs
@@ -92,16 +92,19 @@ impl PakReader {
 
         for ver in Version::iter() {
             match Pak::read(&mut *reader, ver, key.as_ref()) {
-                Ok(pak) => {
-                    return Ok(PakReader { pak, key });
-                }
-                Err(err) => {
-                    writeln!(log, "trying version {} failed: {}", ver, err)?;
-                    continue;
-                }
+                Ok(pak) => return Ok(Self { pak, key }),
+                Err(err) => writeln!(log, "trying version {} failed: {}", ver, err)?,
             }
         }
         Err(super::Error::UnsuportedOrEncrypted(log))
+    }
+
+    pub fn new<R: Read + Seek>(
+        reader: &mut R,
+        version: super::Version,
+        key: Option<aes::Aes256>,
+    ) -> Result<Self, super::Error> {
+        Pak::read(reader, version, key.as_ref()).map(|pak| Self { pak, key })
     }
 
     pub fn version(&self) -> super::Version {

--- a/repak/src/pak.rs
+++ b/repak/src/pak.rs
@@ -84,14 +84,14 @@ fn decrypt(key: &Option<aes::Aes256>, bytes: &mut [u8]) -> Result<(), super::Err
 
 impl PakReader {
     pub fn new_any<R: Read + Seek>(
-        mut reader: R,
+        reader: &mut R,
         key: Option<aes::Aes256>,
     ) -> Result<Self, super::Error> {
         use std::fmt::Write;
         let mut log = "\n".to_owned();
 
         for ver in Version::iter() {
-            match Pak::read(&mut reader, ver, key.clone()) {
+            match Pak::read(&mut *reader, ver, key.clone()) {
                 Ok(pak) => {
                     return Ok(PakReader { pak, key });
                 }

--- a/repak_cli/src/main.rs
+++ b/repak_cli/src/main.rs
@@ -175,7 +175,7 @@ fn main() -> Result<(), repak::Error> {
 }
 
 fn info(aes_key: Option<aes::Aes256>, action: ActionInfo) -> Result<(), repak::Error> {
-    let pak = repak::PakReader::new_any(BufReader::new(File::open(action.input)?), aes_key)?;
+    let pak = repak::PakReader::new_any(&mut BufReader::new(File::open(action.input)?), aes_key)?;
     println!("mount point: {}", pak.mount_point());
     println!("version: {}", pak.version());
     println!("version major: {}", pak.version().version_major());
@@ -186,7 +186,7 @@ fn info(aes_key: Option<aes::Aes256>, action: ActionInfo) -> Result<(), repak::E
 }
 
 fn list(aes_key: Option<aes::Aes256>, action: ActionList) -> Result<(), repak::Error> {
-    let pak = repak::PakReader::new_any(BufReader::new(File::open(action.input)?), aes_key)?;
+    let pak = repak::PakReader::new_any(&mut BufReader::new(File::open(action.input)?), aes_key)?;
 
     let mount_point = PathBuf::from(pak.mount_point());
     let prefix = Path::new(&action.strip_prefix);
@@ -215,8 +215,7 @@ fn list(aes_key: Option<aes::Aes256>, action: ActionList) -> Result<(), repak::E
 }
 
 fn hash_list(aes_key: Option<aes::Aes256>, action: ActionHashList) -> Result<(), repak::Error> {
-    let mut reader = BufReader::new(File::open(&action.input)?);
-    let pak = repak::PakReader::new_any(&mut reader, aes_key)?;
+    let pak = repak::PakReader::new_any(&mut BufReader::new(File::open(&action.input)?), aes_key)?;
 
     let mount_point = PathBuf::from(pak.mount_point());
     let prefix = Path::new(&action.strip_prefix);
@@ -271,7 +270,7 @@ fn hash_list(aes_key: Option<aes::Aes256>, action: ActionHashList) -> Result<(),
 const STYLE: &str = "[{elapsed_precise}] [{wide_bar}] {pos}/{len} ({eta})";
 
 fn unpack(aes_key: Option<aes::Aes256>, action: ActionUnpack) -> Result<(), repak::Error> {
-    let pak = repak::PakReader::new_any(BufReader::new(File::open(&action.input)?), aes_key)?;
+    let pak = repak::PakReader::new_any(&mut BufReader::new(File::open(&action.input)?), aes_key)?;
     let output = action
         .output
         .map(PathBuf::from)


### PR DESCRIPTION
since we're still not sure about where to go with features I went ahead with some api and performance improvements
- `Pak::read` now takes a mutable reference to a reader since it doesn't need to consume or store it (the `&mut *` is just a reborrow - it doesn't actually have a performance impact since nothing is cloned or moved)
- encrypt takes an `Option<&Aes>` instead of an `&Option<Aes>` which gets rid of a bunch of uneccessary key clones
- a `new` method has been added for cases when the game is known 