### PR TITLE
Features redo

### DIFF
--- a/repak/Cargo.toml
+++ b/repak/Cargo.toml
@@ -29,3 +29,6 @@ hex = { workspace = true, optional = true }
 [dev-dependencies]
 base64 = { workspace = true }
 paste = "1.0.11"
+
+[package.metadata.cargo-all-features]
+denylist = ["oodle"]

--- a/repak/Cargo.toml
+++ b/repak/Cargo.toml
@@ -6,19 +6,24 @@ license.workspace = true
 version.workspace = true
 edition.workspace = true
 
+[features]
+default = ["compression"]
+compression = ["dep:flate2", "dep:zstd"]
+oodle = ["dep:libloading", "dep:ureq", "dep:once_cell", "dep:hex-literal", "dep:hex"]
+
 [dependencies]
 byteorder = "1.4"
 aes = "0.8"
-flate2 = "1.0"
+flate2 = { version = "1.0", optional = true }
+zstd = { version = "0.12", optional = true }
 thiserror = "1.0"
 sha1 = "0.10.5"
 strum = { workspace = true }
-libloading = "0.7.4"
-ureq = "2.6.2"
-hex-literal = "0.4.1"
-hex = { workspace = true }
-once_cell = "1.17.1"
-zstd = "0.12.3"
+libloading = { version = "0.7", optional = true }
+ureq = { version = "2.6", optional = true }
+once_cell = { version = "1.17", optional = true}
+hex-literal = { version = "0.4", optional = true }
+hex = { workspace = true, optional = true }
 
 [dev-dependencies]
 base64 = { workspace = true }

--- a/repak/Cargo.toml
+++ b/repak/Cargo.toml
@@ -7,13 +7,14 @@ version.workspace = true
 edition.workspace = true
 
 [features]
-default = ["compression"]
+default = ["compression", "encryption"]
 compression = ["dep:flate2", "dep:zstd"]
 oodle = ["dep:libloading", "dep:ureq", "dep:once_cell", "dep:hex-literal", "dep:hex"]
+encryption = ["dep:aes"]
 
 [dependencies]
 byteorder = "1.4"
-aes = "0.8"
+aes = { version = "0.8", optional = true }
 flate2 = { version = "1.0", optional = true }
 zstd = { version = "0.12", optional = true }
 thiserror = "1.0"

--- a/repak/src/entry.rs
+++ b/repak/src/entry.rs
@@ -311,7 +311,7 @@ impl Entry {
         reader: &mut R,
         version: Version,
         compression: &[Compression],
-        key: &super::Key,
+        #[allow(unused)] key: &super::Key,
         buf: &mut W,
     ) -> Result<(), super::Error> {
         reader.seek(io::SeekFrom::Start(self.offset))?;
@@ -355,6 +355,7 @@ impl Entry {
                     },
                 )
                 .collect::<Vec<_>>(),
+            #[allow(clippy::single_range_in_vec_init)]
             None => vec![0..data.len()],
         };
 

--- a/repak/src/entry.rs
+++ b/repak/src/entry.rs
@@ -316,6 +316,7 @@ impl Entry {
     ) -> Result<(), super::Error> {
         reader.seek(io::SeekFrom::Start(self.offset))?;
         Entry::read(reader, version)?;
+        #[cfg(any(feature = "compression", feature = "oodle"))]
         let data_offset = reader.stream_position()?;
         #[allow(unused_mut)]
         let mut data = reader.read_len(match self.is_encrypted() {
@@ -338,6 +339,7 @@ impl Entry {
             }
         }
 
+        #[cfg(any(feature = "compression", feature = "oodle"))]
         let ranges = match &self.blocks {
             Some(blocks) => blocks
                 .iter()

--- a/repak/src/error.rs
+++ b/repak/src/error.rs
@@ -9,6 +9,13 @@ pub enum Error {
     #[error("expect 256 bit AES key as base64 or hex string")]
     Aes,
 
+    // feature errors
+    #[error("enable the compression feature to read compressed paks")]
+    Compression,
+
+    #[error("enable the oodle feature to read oodle paks")]
+    Oodle,
+
     // std errors
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
@@ -22,6 +29,7 @@ pub enum Error {
     #[error("utf16 conversion: {0}")]
     Utf16(#[from] std::string::FromUtf16Error),
 
+    #[cfg(feature = "oodle")]
     #[error("ureq error: {0}")]
     Ureq(#[from] Box<ureq::Error>), // boxed because ureq::Error is quite large
 
@@ -34,9 +42,6 @@ pub enum Error {
 
     #[error("found magic of {0:#x} instead of {:#x}", super::MAGIC)]
     Magic(u32),
-
-    #[error("Oodle compression only supported on Windows (or WINE)")]
-    Oodle,
 
     #[error("Could not load oo2core_9_win64.dll")]
     OodleFailed,
@@ -72,7 +77,7 @@ pub enum Error {
     OsString(std::ffi::OsString),
 
     #[error("{0}version unsupported or is encrypted (possibly missing --aes-key?)")]
-    UnsuportedOrEncrypted(String),
+    UnsupportedOrEncrypted(String),
 
     #[error("{0}")]
     Other(String),

--- a/repak/src/error.rs
+++ b/repak/src/error.rs
@@ -16,7 +16,14 @@ pub enum Error {
     #[error("enable the encryption feature to read encrypted paks")]
     Encryption,
 
-    #[error("enable the oodle feature to read oodle paks")]
+    #[cfg_attr(
+        windows,
+        error("enable the oodle feature to read Oodle compressed paks")
+    )]
+    #[cfg_attr(
+        not(windows),
+        error("Oodle compression only supported on Windows (or WINE)")
+    )]
     Oodle,
 
     // std errors

--- a/repak/src/error.rs
+++ b/repak/src/error.rs
@@ -13,6 +13,9 @@ pub enum Error {
     #[error("enable the compression feature to read compressed paks")]
     Compression,
 
+    #[error("enable the encryption feature to read encrypted paks")]
+    Encryption,
+
     #[error("enable the oodle feature to read oodle paks")]
     Oodle,
 

--- a/repak/src/lib.rs
+++ b/repak/src/lib.rs
@@ -131,12 +131,9 @@ pub(crate) enum Key {
     None,
 }
 
-impl From<Option<aes::Aes256>> for Key {
-    fn from(value: Option<aes::Aes256>) -> Self {
-        match value {
-            #[cfg(feature = "encryption")]
-            Some(key) => Self::Some(key),
-            _ => Self::None,
-        }
+#[cfg(feature = "encryption")]
+impl From<aes::Aes256> for Key {
+    fn from(value: aes::Aes256) -> Self {
+        Self::Some(value)
     }
 }

--- a/repak/src/lib.rs
+++ b/repak/src/lib.rs
@@ -7,6 +7,9 @@ mod pak;
 
 pub use {error::*, pak::*};
 
+#[cfg(all(feature = "oodle", not(target_os = "windows")))]
+compile_error!("Oodle compression only supported on Windows (or WINE)");
+
 pub const MAGIC: u32 = 0x5A6F12E1;
 
 #[derive(

--- a/repak/src/lib.rs
+++ b/repak/src/lib.rs
@@ -122,3 +122,21 @@ pub enum Compression {
     Oodle,
     Zstd,
 }
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub(crate) enum Key {
+    #[cfg(feature = "encryption")]
+    Some(aes::Aes256),
+    None,
+}
+
+impl From<Option<aes::Aes256>> for Key {
+    fn from(value: Option<aes::Aes256>) -> Self {
+        match value {
+            #[cfg(feature = "encryption")]
+            Some(key) => Self::Some(key),
+            _ => Self::None,
+        }
+    }
+}

--- a/repak/src/pak.rs
+++ b/repak/src/pak.rs
@@ -1,5 +1,6 @@
 use super::ext::{ReadExt, WriteExt};
 use super::{Version, VersionMajor};
+#[cfg(feature = "encryption")]
 use aes::Aes256;
 use byteorder::{ReadBytesExt, WriteBytesExt, LE};
 use std::collections::BTreeMap;
@@ -8,6 +9,7 @@ use std::io::{self, Read, Seek, Write};
 #[derive(Debug)]
 pub struct PakReader {
     pak: Pak,
+    #[cfg(feature = "encryption")]
     key: Option<aes::Aes256>,
 }
 
@@ -15,6 +17,7 @@ pub struct PakReader {
 pub struct PakWriter<W: Write + Seek> {
     pak: Pak,
     writer: W,
+    #[cfg(feature = "encryption")]
     key: Option<aes::Aes256>,
 }
 
@@ -70,6 +73,7 @@ impl Index {
     }
 }
 
+#[cfg(feature = "encryption")]
 fn decrypt(key: Option<&aes::Aes256>, bytes: &mut [u8]) -> Result<(), super::Error> {
     if let Some(key) = key {
         use aes::cipher::BlockDecrypt;
@@ -83,28 +87,79 @@ fn decrypt(key: Option<&aes::Aes256>, bytes: &mut [u8]) -> Result<(), super::Err
 }
 
 impl PakReader {
-    pub fn new_any<R: Read + Seek>(
+    #[cfg(not(feature = "encryption"))]
+    pub fn new_any<R: Read + Seek>(reader: &mut R) -> Result<Self, super::Error> {
+        Self::new_any_inner(reader)
+    }
+
+    #[cfg(feature = "encryption")]
+    pub fn new_any_with_key<R: Read + Seek>(
         reader: &mut R,
         key: Option<aes::Aes256>,
+    ) -> Result<Self, super::Error> {
+        Self::new_any_inner(reader, key)
+    }
+
+    fn new_any_inner<R: Read + Seek>(
+        reader: &mut R,
+        #[cfg(feature = "encryption")] key: Option<aes::Aes256>,
     ) -> Result<Self, super::Error> {
         use std::fmt::Write;
         let mut log = "\n".to_owned();
 
         for ver in Version::iter() {
-            match Pak::read(&mut *reader, ver, key.as_ref()) {
-                Ok(pak) => return Ok(Self { pak, key }),
+            match Pak::read(
+                &mut *reader,
+                ver,
+                #[cfg(feature = "encryption")]
+                key.as_ref(),
+            ) {
+                Ok(pak) => {
+                    return Ok(Self {
+                        pak,
+                        #[cfg(feature = "encryption")]
+                        key,
+                    })
+                }
                 Err(err) => writeln!(log, "trying version {} failed: {}", ver, err)?,
             }
         }
         Err(super::Error::UnsupportedOrEncrypted(log))
     }
 
+    #[cfg(not(feature = "encryption"))]
     pub fn new<R: Read + Seek>(
+        reader: &mut R,
+        version: super::Version,
+    ) -> Result<Self, super::Error> {
+        Self::new_inner(reader, version)
+    }
+
+    #[cfg(feature = "encryption")]
+    pub fn new_with_key<R: Read + Seek>(
         reader: &mut R,
         version: super::Version,
         key: Option<aes::Aes256>,
     ) -> Result<Self, super::Error> {
-        Pak::read(reader, version, key.as_ref()).map(|pak| Self { pak, key })
+        Self::new_inner(reader, version, key)
+    }
+
+    fn new_inner<R: Read + Seek>(
+        reader: &mut R,
+        version: super::Version,
+        #[cfg(feature = "encryption")] key: Option<aes::Aes256>,
+    ) -> Result<Self, super::Error> {
+        Pak::read(
+            reader,
+            version,
+            #[cfg(feature = "encryption")]
+            key.as_ref(),
+        )
+        .map(|pak| Self {
+            pak,
+            #[cfg(feature = "encryption")]
+            key,
+        })
     }
 
     pub fn version(&self) -> super::Version {
@@ -140,6 +195,7 @@ impl PakReader {
                 reader,
                 self.pak.version,
                 &self.pak.compression,
+                #[cfg(feature = "encryption")]
                 self.key.as_ref(),
                 writer,
             ),
@@ -158,6 +214,7 @@ impl PakReader {
         writer.seek(io::SeekFrom::Start(self.pak.index_offset.unwrap()))?;
         Ok(PakWriter {
             pak: self.pak,
+            #[cfg(feature = "encryption")]
             key: self.key,
             writer,
         })
@@ -165,7 +222,21 @@ impl PakReader {
 }
 
 impl<W: Write + Seek> PakWriter<W> {
+    #[cfg(not(feature = "encryption"))]
     pub fn new(
+        writer: W,
+        version: Version,
+        mount_point: String,
+        path_hash_seed: Option<u64>,
+    ) -> Self {
+        PakWriter {
+            pak: Pak::new(version, mount_point, path_hash_seed),
+            writer,
+        }
+    }
+
+    #[cfg(feature = "encryption")]
+    pub fn new_with_key(
         writer: W,
         key: Option<aes::Aes256>,
         version: Version,
@@ -175,6 +246,21 @@ impl<W: Write + Seek> PakWriter<W> {
         PakWriter {
             pak: Pak::new(version, mount_point, path_hash_seed),
             writer,
+            key,
+        }
+    }
+
+    fn new_inner(
+        writer: W,
+        #[cfg(feature = "encryption")] key: Option<aes::Aes256>,
+        version: Version,
+        mount_point: String,
+        path_hash_seed: Option<u64>,
+    ) -> Self {
+        PakWriter {
+            pak: Pak::new(version, mount_point, path_hash_seed),
+            writer,
+            #[cfg(feature = "encryption")]
             key,
         }
     }
@@ -219,7 +305,11 @@ impl<W: Write + Seek> PakWriter<W> {
     }
 
     pub fn write_index(mut self) -> Result<W, super::Error> {
-        self.pak.write(&mut self.writer, self.key)?;
+        self.pak.write(
+            &mut self.writer,
+            #[cfg(feature = "encryption")]
+            self.key,
+        )?;
         Ok(self.writer)
     }
 }
@@ -228,17 +318,21 @@ impl Pak {
     fn read<R: Read + Seek>(
         reader: &mut R,
         version: super::Version,
-        key: Option<&aes::Aes256>,
+        #[cfg(feature = "encryption")] key: Option<&aes::Aes256>,
     ) -> Result<Self, super::Error> {
         // read footer to get index, encryption & compression info
         reader.seek(io::SeekFrom::End(-version.size()))?;
         let footer = super::footer::Footer::read(reader, version)?;
         // read index to get all the entry info
         reader.seek(io::SeekFrom::Start(footer.index_offset))?;
+        #[allow(unused_mut)]
         let mut index = reader.read_len(footer.index_size as usize)?;
 
         // decrypt index if needed
         if footer.encrypted {
+            #[cfg(not(feature = "encryption"))]
+            return Err(super::Error::Encryption);
+            #[cfg(feature = "encryption")]
             decrypt(key, &mut index)?;
         }
 
@@ -260,6 +354,9 @@ impl Pak {
                 // TODO verify hash
 
                 if footer.encrypted {
+                    #[cfg(not(feature = "encryption"))]
+                    return Err(super::Error::Encryption);
+                    #[cfg(feature = "encryption")]
                     decrypt(key, &mut path_hash_index_buf)?;
                 }
 
@@ -283,11 +380,15 @@ impl Pak {
                 let _full_directory_index_hash = index.read_len(20)?;
 
                 reader.seek(io::SeekFrom::Start(full_directory_index_offset))?;
+                #[allow(unused_mut)]
                 let mut full_directory_index =
                     reader.read_len(full_directory_index_size as usize)?;
                 // TODO verify hash
 
                 if footer.encrypted {
+                    #[cfg(not(feature = "encryption"))]
+                    return Err(super::Error::Encryption);
+                    #[cfg(feature = "encryption")]
                     decrypt(key, &mut full_directory_index)?;
                 }
                 let mut fdi = io::Cursor::new(full_directory_index);
@@ -367,7 +468,7 @@ impl Pak {
     fn write<W: Write + Seek>(
         &self,
         writer: &mut W,
-        _key: Option<aes::Aes256>,
+        #[cfg(feature = "encryption")] _key: Option<aes::Aes256>,
     ) -> Result<(), super::Error> {
         let index_offset = writer.stream_position()?;
 
@@ -594,6 +695,7 @@ fn pad_zeros_to_alignment(v: &mut Vec<u8>, alignment: usize) {
     assert!(v.len() % alignment == 0);
 }
 
+#[cfg(feature = "encryption")]
 fn encrypt(key: Aes256, bytes: &mut [u8]) {
     use aes::cipher::BlockEncrypt;
     for chunk in bytes.chunks_mut(16) {

--- a/repak/src/pak.rs
+++ b/repak/src/pak.rs
@@ -226,13 +226,13 @@ impl<W: Write + Seek> PakWriter<W> {
 
 impl Pak {
     fn read<R: Read + Seek>(
-        mut reader: R,
+        reader: &mut R,
         version: super::Version,
         key: Option<&aes::Aes256>,
     ) -> Result<Self, super::Error> {
         // read footer to get index, encryption & compression info
         reader.seek(io::SeekFrom::End(-version.size()))?;
-        let footer = super::footer::Footer::read(&mut reader, version)?;
+        let footer = super::footer::Footer::read(reader, version)?;
         // read index to get all the entry info
         reader.seek(io::SeekFrom::Start(footer.index_offset))?;
         let mut index = reader.read_len(footer.index_size as usize)?;

--- a/repak/src/pak.rs
+++ b/repak/src/pak.rs
@@ -96,7 +96,7 @@ impl PakReader {
                 Err(err) => writeln!(log, "trying version {} failed: {}", ver, err)?,
             }
         }
-        Err(super::Error::UnsuportedOrEncrypted(log))
+        Err(super::Error::UnsupportedOrEncrypted(log))
     }
 
     pub fn new<R: Read + Seek>(

--- a/repak/src/pak.rs
+++ b/repak/src/pak.rs
@@ -321,7 +321,7 @@ impl Pak {
     fn read<R: Read + Seek>(
         reader: &mut R,
         version: super::Version,
-        key: &super::Key,
+        #[allow(unused)] key: &super::Key,
     ) -> Result<Self, super::Error> {
         // read footer to get index, encryption & compression info
         reader.seek(io::SeekFrom::End(-version.size()))?;

--- a/repak/tests/test.rs
+++ b/repak/tests/test.rs
@@ -96,7 +96,7 @@ fn test_read(version: repak::Version, _file_name: &str, bytes: &[u8]) {
     let len = inner_reader.seek(SeekFrom::End(0)).unwrap();
     let mut reader = ReadCounter::new_size(inner_reader, len as usize);
 
-    let pak = repak::PakReader::new_any_with_key(&mut reader, Some(key)).unwrap();
+    let pak = repak::PakReader::new_any_with_key(&mut reader, key).unwrap();
 
     assert_eq!(pak.mount_point(), "../mount/point/root/");
     assert_eq!(pak.version(), version);
@@ -159,12 +159,11 @@ fn test_write(_version: repak::Version, _file_name: &str, bytes: &[u8]) {
         .unwrap();
 
     let mut reader = std::io::Cursor::new(bytes);
-    let pak_reader = repak::PakReader::new_any_with_key(&mut reader, Some(key)).unwrap();
+    let pak_reader = repak::PakReader::new_any_with_key(&mut reader, key).unwrap();
 
     let writer = Cursor::new(vec![]);
-    let mut pak_writer = repak::PakWriter::new_with_key(
+    let mut pak_writer = repak::PakWriter::new(
         writer,
-        None,
         pak_reader.version(),
         pak_reader.mount_point().to_owned(),
         Some(0x205C5A7D),
@@ -191,7 +190,7 @@ fn test_rewrite_index(_version: repak::Version, _file_name: &str, bytes: &[u8]) 
         .unwrap();
 
     let mut buf = std::io::Cursor::new(bytes.to_vec());
-    let pak_reader = repak::PakReader::new_any_with_key(&mut buf, Some(key)).unwrap();
+    let pak_reader = repak::PakReader::new_any_with_key(&mut buf, key).unwrap();
 
     let rewrite = pak_reader
         .into_pakwriter(buf)

--- a/repak/tests/test.rs
+++ b/repak/tests/test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "default")]
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use paste::paste;
 use std::io::{self, Cursor, Read, Seek, SeekFrom};

--- a/repak/tests/test.rs
+++ b/repak/tests/test.rs
@@ -96,7 +96,7 @@ fn test_read(version: repak::Version, _file_name: &str, bytes: &[u8]) {
     let len = inner_reader.seek(SeekFrom::End(0)).unwrap();
     let mut reader = ReadCounter::new_size(inner_reader, len as usize);
 
-    let pak = repak::PakReader::new_any(&mut reader, Some(key)).unwrap();
+    let pak = repak::PakReader::new_any_with_key(&mut reader, Some(key)).unwrap();
 
     assert_eq!(pak.mount_point(), "../mount/point/root/");
     assert_eq!(pak.version(), version);
@@ -159,10 +159,10 @@ fn test_write(_version: repak::Version, _file_name: &str, bytes: &[u8]) {
         .unwrap();
 
     let mut reader = std::io::Cursor::new(bytes);
-    let pak_reader = repak::PakReader::new_any(&mut reader, Some(key)).unwrap();
+    let pak_reader = repak::PakReader::new_any_with_key(&mut reader, Some(key)).unwrap();
 
     let writer = Cursor::new(vec![]);
-    let mut pak_writer = repak::PakWriter::new(
+    let mut pak_writer = repak::PakWriter::new_with_key(
         writer,
         None,
         pak_reader.version(),
@@ -191,7 +191,7 @@ fn test_rewrite_index(_version: repak::Version, _file_name: &str, bytes: &[u8]) 
         .unwrap();
 
     let mut buf = std::io::Cursor::new(bytes.to_vec());
-    let pak_reader = repak::PakReader::new_any(&mut buf, Some(key)).unwrap();
+    let pak_reader = repak::PakReader::new_any_with_key(&mut buf, Some(key)).unwrap();
 
     let rewrite = pak_reader
         .into_pakwriter(buf)

--- a/repak_cli/Cargo.toml
+++ b/repak_cli/Cargo.toml
@@ -10,6 +10,11 @@ edition.workspace = true
 name = "repak"
 path = "src/main.rs"
 
+[target.'cfg(windows)'.dependencies]
+repak = { path = "../repak", features = ["oodle"] }
+[target.'cfg(not(windows))'.dependencies]
+repak = { path = "../repak" }
+
 [dependencies]
 aes = { workspace = true }
 base64 = { workspace = true }
@@ -19,6 +24,5 @@ indicatif = { version = "0.17.3", features = ["rayon"] }
 path-clean = "0.1.0"
 path-slash = "0.2.1"
 rayon = "1.6.1"
-repak = { version = "0.1.7", path = "../repak", features = ["oodle"] }
 sha2 = "0.10.7"
 strum = { workspace = true }

--- a/repak_cli/Cargo.toml
+++ b/repak_cli/Cargo.toml
@@ -19,6 +19,6 @@ indicatif = { version = "0.17.3", features = ["rayon"] }
 path-clean = "0.1.0"
 path-slash = "0.2.1"
 rayon = "1.6.1"
-repak = { version = "0.1.7", path = "../repak" }
+repak = { version = "0.1.7", path = "../repak", features = ["oodle"] }
 sha2 = "0.10.7"
 strum = { workspace = true }

--- a/repak_cli/src/main.rs
+++ b/repak_cli/src/main.rs
@@ -175,7 +175,7 @@ fn main() -> Result<(), repak::Error> {
 }
 
 fn info(aes_key: Option<aes::Aes256>, action: ActionInfo) -> Result<(), repak::Error> {
-    let pak = repak::PakReader::new_any_with_key(
+    let pak = repak::PakReader::new_any_with_optional_key(
         &mut BufReader::new(File::open(action.input)?),
         aes_key,
     )?;
@@ -189,7 +189,7 @@ fn info(aes_key: Option<aes::Aes256>, action: ActionInfo) -> Result<(), repak::E
 }
 
 fn list(aes_key: Option<aes::Aes256>, action: ActionList) -> Result<(), repak::Error> {
-    let pak = repak::PakReader::new_any_with_key(
+    let pak = repak::PakReader::new_any_with_optional_key(
         &mut BufReader::new(File::open(action.input)?),
         aes_key,
     )?;
@@ -221,7 +221,7 @@ fn list(aes_key: Option<aes::Aes256>, action: ActionList) -> Result<(), repak::E
 }
 
 fn hash_list(aes_key: Option<aes::Aes256>, action: ActionHashList) -> Result<(), repak::Error> {
-    let pak = repak::PakReader::new_any_with_key(
+    let pak = repak::PakReader::new_any_with_optional_key(
         &mut BufReader::new(File::open(&action.input)?),
         aes_key,
     )?;
@@ -279,7 +279,7 @@ fn hash_list(aes_key: Option<aes::Aes256>, action: ActionHashList) -> Result<(),
 const STYLE: &str = "[{elapsed_precise}] [{wide_bar}] {pos}/{len} ({eta})";
 
 fn unpack(aes_key: Option<aes::Aes256>, action: ActionUnpack) -> Result<(), repak::Error> {
-    let pak = repak::PakReader::new_any_with_key(
+    let pak = repak::PakReader::new_any_with_optional_key(
         &mut BufReader::new(File::open(&action.input)?),
         aes_key,
     )?;
@@ -400,7 +400,7 @@ fn pack(args: ActionPack) -> Result<(), repak::Error> {
     collect_files(&mut paths, input_path)?;
     paths.sort();
 
-    let mut pak = repak::PakWriter::new_with_key(
+    let mut pak = repak::PakWriter::new_with_optional_key(
         BufWriter::new(File::create(&output)?),
         None,
         args.version,
@@ -435,7 +435,7 @@ fn pack(args: ActionPack) -> Result<(), repak::Error> {
 
 fn get(aes_key: Option<aes::Aes256>, args: ActionGet) -> Result<(), repak::Error> {
     let mut reader = BufReader::new(File::open(&args.input)?);
-    let pak = repak::PakReader::new_any_with_key(&mut reader, aes_key)?;
+    let pak = repak::PakReader::new_any_with_optional_key(&mut reader, aes_key)?;
     let mount_point = PathBuf::from(pak.mount_point());
     let prefix = Path::new(&args.strip_prefix);
 

--- a/repak_cli/src/main.rs
+++ b/repak_cli/src/main.rs
@@ -175,7 +175,10 @@ fn main() -> Result<(), repak::Error> {
 }
 
 fn info(aes_key: Option<aes::Aes256>, action: ActionInfo) -> Result<(), repak::Error> {
-    let pak = repak::PakReader::new_any(&mut BufReader::new(File::open(action.input)?), aes_key)?;
+    let pak = repak::PakReader::new_any_with_key(
+        &mut BufReader::new(File::open(action.input)?),
+        aes_key,
+    )?;
     println!("mount point: {}", pak.mount_point());
     println!("version: {}", pak.version());
     println!("version major: {}", pak.version().version_major());
@@ -186,7 +189,10 @@ fn info(aes_key: Option<aes::Aes256>, action: ActionInfo) -> Result<(), repak::E
 }
 
 fn list(aes_key: Option<aes::Aes256>, action: ActionList) -> Result<(), repak::Error> {
-    let pak = repak::PakReader::new_any(&mut BufReader::new(File::open(action.input)?), aes_key)?;
+    let pak = repak::PakReader::new_any_with_key(
+        &mut BufReader::new(File::open(action.input)?),
+        aes_key,
+    )?;
 
     let mount_point = PathBuf::from(pak.mount_point());
     let prefix = Path::new(&action.strip_prefix);
@@ -215,7 +221,10 @@ fn list(aes_key: Option<aes::Aes256>, action: ActionList) -> Result<(), repak::E
 }
 
 fn hash_list(aes_key: Option<aes::Aes256>, action: ActionHashList) -> Result<(), repak::Error> {
-    let pak = repak::PakReader::new_any(&mut BufReader::new(File::open(&action.input)?), aes_key)?;
+    let pak = repak::PakReader::new_any_with_key(
+        &mut BufReader::new(File::open(&action.input)?),
+        aes_key,
+    )?;
 
     let mount_point = PathBuf::from(pak.mount_point());
     let prefix = Path::new(&action.strip_prefix);
@@ -270,7 +279,10 @@ fn hash_list(aes_key: Option<aes::Aes256>, action: ActionHashList) -> Result<(),
 const STYLE: &str = "[{elapsed_precise}] [{wide_bar}] {pos}/{len} ({eta})";
 
 fn unpack(aes_key: Option<aes::Aes256>, action: ActionUnpack) -> Result<(), repak::Error> {
-    let pak = repak::PakReader::new_any(&mut BufReader::new(File::open(&action.input)?), aes_key)?;
+    let pak = repak::PakReader::new_any_with_key(
+        &mut BufReader::new(File::open(&action.input)?),
+        aes_key,
+    )?;
     let output = action
         .output
         .map(PathBuf::from)
@@ -388,7 +400,7 @@ fn pack(args: ActionPack) -> Result<(), repak::Error> {
     collect_files(&mut paths, input_path)?;
     paths.sort();
 
-    let mut pak = repak::PakWriter::new(
+    let mut pak = repak::PakWriter::new_with_key(
         BufWriter::new(File::create(&output)?),
         None,
         args.version,
@@ -423,7 +435,7 @@ fn pack(args: ActionPack) -> Result<(), repak::Error> {
 
 fn get(aes_key: Option<aes::Aes256>, args: ActionGet) -> Result<(), repak::Error> {
     let mut reader = BufReader::new(File::open(&args.input)?);
-    let pak = repak::PakReader::new_any(&mut reader, aes_key)?;
+    let pak = repak::PakReader::new_any_with_key(&mut reader, aes_key)?;
     let mount_point = PathBuf::from(pak.mount_point());
     let prefix = Path::new(&args.strip_prefix);
 


### PR DESCRIPTION
redoes #4 so that there are separate methods for each feature
if you want to change the function names to something less verbose go ahead
not sure how to mark functions as requiring a feature tho
also had the idea of making `new_any_with_key` accept an aes key and not excluding `new_any` when encryption is enabled but a lot of the time the user will probably be using options so not 100% sure on that