### PR TITLE
Last api stuff

### DIFF
--- a/repak/src/pak.rs
+++ b/repak/src/pak.rs
@@ -276,16 +276,13 @@ impl<W: Write + Seek> PakWriter<W> {
         self.writer
     }
 
-    pub fn write_file<R: Read>(&mut self, path: &str, reader: &mut R) -> Result<(), super::Error> {
-        let mut data = vec![];
-        reader.read_to_end(&mut data)?;
-
+    pub fn write_file(&mut self, path: &str, data: impl AsRef<[u8]>) -> Result<(), super::Error> {
         use sha1::{Digest, Sha1};
         let mut hasher = Sha1::new();
         hasher.update(&data);
 
         let offset = self.writer.stream_position()?;
-        let len = data.len() as u64;
+        let len = data.as_ref().len() as u64;
 
         let entry = super::entry::Entry {
             offset,
@@ -307,7 +304,7 @@ impl<W: Write + Seek> PakWriter<W> {
 
         self.pak.index.add_entry(path, entry);
 
-        self.writer.write_all(&data)?;
+        self.writer.write_all(data.as_ref())?;
         Ok(())
     }
 

--- a/repak/tests/test.rs
+++ b/repak/tests/test.rs
@@ -172,9 +172,7 @@ fn test_write(_version: repak::Version, _file_name: &str, bytes: &[u8]) {
 
     for path in pak_reader.files() {
         let data = pak_reader.get(&path, &mut reader).unwrap();
-        pak_writer
-            .write_file(&path, &mut std::io::Cursor::new(data))
-            .unwrap();
+        pak_writer.write_file(&path, data).unwrap();
     }
 
     assert!(pak_writer.write_index().unwrap().into_inner() == reader.into_inner());

--- a/repak_cli/src/main.rs
+++ b/repak_cli/src/main.rs
@@ -423,7 +423,7 @@ fn pack(args: ActionPack) -> Result<(), repak::Error> {
         if args.verbose {
             progress.println(format!("packing {}", &rel));
         }
-        pak.write_file(rel, &mut BufReader::new(File::open(p)?))
+        pak.write_file(rel, std::fs::read(p)?)
     })?;
 
     pak.write_index()?;


### PR DESCRIPTION
this'll probably be the last api one now since I'm really happy with everything else (except files() returning a vec but otherwise it would leak a private type and passing in an aes key rather than a slice but I get users can make aes keys in other ways)
- commented out the path hash stuff since it's not used at all and so is just wasting time
- unhid the use of vec in write_file since e.g you might have just written something to a vec and it's being rewritten to another one. since hash requires something AsRef<[u8]> it nows accepts that
- adds game_name function to PakReader for asset path canonicalisation