### PR TITLE
Use Oodle decompression for hash_list

### DIFF
--- a/repak_cli/src/main.rs
+++ b/repak_cli/src/main.rs
@@ -238,7 +238,7 @@ fn list(aes_key: Option<aes::Aes256>, action: ActionList) -> Result<(), repak::E
 }
 
 fn hash_list(aes_key: Option<aes::Aes256>, action: ActionHashList) -> Result<(), repak::Error> {
-    let mut builder = repak::PakBuilder::new();
+    let mut builder = repak::PakBuilder::new().oodle(oodle_loader::decompress);
     if let Some(aes_key) = aes_key {
         builder = builder.key(aes_key);
     }


### PR DESCRIPTION
When using the repak-cli "hash-list" parameter, an error is shown which indicates that the Oodle DLL was not loaded:

Error: pointer to OodleLZ_Decompress was not provided

This commit uses the oodle_loader to load the "OodleLZ_Decompress" symbol similar to the "get" function. 