### PR TITLE
Add compression output to `repak info` command

### DIFF
--- a/repak/src/pak.rs
+++ b/repak/src/pak.rs
@@ -201,6 +201,10 @@ impl PakReader {
         self.pak.encryption_guid
     }
 
+    pub fn compression(&self) -> Option<&Compression> {
+        self.pak.compression.iter().find_map(|c| c.as_ref())
+    }
+
     pub fn path_hash_seed(&self) -> Option<u64> {
         self.pak.index.path_hash_seed
     }

--- a/repak_cli/src/main.rs
+++ b/repak_cli/src/main.rs
@@ -199,7 +199,10 @@ fn info(aes_key: Option<aes::Aes256>, action: ActionInfo) -> Result<(), repak::E
     println!("version: {}", pak.version());
     println!("version major: {}", pak.version().version_major());
     println!("encrypted index: {}", pak.encrypted_index());
-    println!("encrytion guid: {:032X?}", pak.encryption_guid());
+    println!("encryption guid: {:032X?}", pak.encryption_guid());
+    if let Some(c) = pak.compression() {
+        println!("compression: {}", c);
+    }
     println!("path hash seed: {:08X?}", pak.path_hash_seed());
     println!("{} file entries", pak.files().len());
     Ok(())


### PR DESCRIPTION
```bash
>repak info MyPak.pak
mount point: ../../../ASD/Content/MyPak/
version: V9
version major: FrozenIndex
encrypted index: false
encryption guid: Some(00000000000000000000000000000000)
compression: Zlib
path hash seed: None
92 file entriess
```