### PR TITLE
fix: skip deleted PAK entries to prevent negate overflow

### DIFF
--- a/repak/src/pak.rs
+++ b/repak/src/pak.rs
@@ -481,6 +481,11 @@ impl Pak {
                 let mut encoded_entries = io::Cursor::new(&encoded_entries);
                 for (dir_name, dir) in fdi {
                     for (file_name, encoded_offset) in dir {
+                        // i32::MIN (0x80000000) is a deleted/pruned entry sentinel
+                        // in the UE5 PAK format — skip it to avoid negate overflow.
+                        if *encoded_offset == i32::MIN {
+                            continue;
+                        }
                         let entry = if *encoded_offset >= 0 {
                             encoded_entries.set_position(*encoded_offset as u64);
                             Entry::read_encoded(&mut encoded_entries, version)?


### PR DESCRIPTION
UE5 PAK full directory index uses `i32::MIN` (`0x80000000`) as a sentinel for deleted/pruned entries. When this value reaches `(-*encoded_offset) as usize - 1`, repak currently panics with `attempt to negate with overflow` in debug builds.

This was previously guarded when `encoded_offset` was `u32`, but the guard was lost in 1ef2c6f when non-encoded entry support was added and the type changed to `i32`

This affects patch PAKs (e.g., `_5_P`, `_8_P` suffixes) that contain pruned entries from earlier patches

- Tested against 150 UE5 PAK files including 45 patch-level PAKs that previously caused panics
- All PAKs now parse successfully with zero failures

EDIT: To be clear in case testing is wanted, the PAKs are from the latest versions of Borderlands 4. However, the UE5 source code (IPlatformFilePak.h:602-608) shows that this is a case which can exist outside of just BL4.